### PR TITLE
Change logic of giving item and add a augment check

### DIFF
--- a/arena.py
+++ b/arena.py
@@ -307,13 +307,13 @@ class Arena:
 
     def pick_augment(self) -> None:
         """Picks an augment from user defined augment priority list or defaults to first augment"""
-        augments: list = []
         while True:
+            augments: list = []
             for coords in screen_coords.AUGMENT_POS:
                 augment: str = ocr.get_text(
                     screenxy=coords.get_coords(), scale=3, psm=7)
                 augments.append(augment)
-            if len(augments) != 0:
+            if len(augments) == 3 and '' not in augments:
                 break
 
         for augment in augments:

--- a/arena.py
+++ b/arena.py
@@ -173,9 +173,11 @@ class Arena:
 
     def add_item_to_champs(self, item_index: int) -> None:
         """Iterates through champions in the board and checks if the champion needs items"""
-        for champ in self.board:
-            if champ.does_need_items() and self.items[item_index] is not None:
-                self.add_item_to_champ(item_index, champ)
+        for champName in comps.COMP:
+            for champ in self.board:
+                if champName == champ.name:
+                    if champ.does_need_items() and self.items[item_index] is not None:
+                        self.add_item_to_champ(item_index, champ)
 
     def add_item_to_champ(self, item_index: int, champ: Champion) -> None:
         """Takes item index and champ and applies the item"""
@@ -306,10 +308,13 @@ class Arena:
     def pick_augment(self) -> None:
         """Picks an augment from user defined augment priority list or defaults to first augment"""
         augments: list = []
-        for coords in screen_coords.AUGMENT_POS:
-            augment: str = ocr.get_text(
-                screenxy=coords.get_coords(), scale=3, psm=7)
-            augments.append(augment)
+        while True:
+            for coords in screen_coords.AUGMENT_POS:
+                augment: str = ocr.get_text(
+                    screenxy=coords.get_coords(), scale=3, psm=7)
+                augments.append(augment)
+            if len(augments) != 0:
+                break
 
         for augment in augments:
             for potential in comps.AUGMENTS:

--- a/arena.py
+++ b/arena.py
@@ -308,6 +308,7 @@ class Arena:
     def pick_augment(self) -> None:
         """Picks an augment from user defined augment priority list or defaults to first augment"""
         while True:
+            sleep(1)
             augments: list = []
             for coords in screen_coords.AUGMENT_POS:
                 augment: str = ocr.get_text(
@@ -316,8 +317,8 @@ class Arena:
             if len(augments) == 3 and '' not in augments:
                 break
 
-        for augment in augments:
-            for potential in comps.AUGMENTS:
+        for potential in comps.AUGMENTS:
+            for augment in augments:
                 if potential in augment:
                     print(f"  Choosing augment {augment}")
                     mk_functions.left_click(screen_coords.AUGMENT_LOC[augments.index(augment)].get_coords())

--- a/comps.py
+++ b/comps.py
@@ -2,6 +2,7 @@
 Team composition used by the bot
 Comps come from https://tftactics.gg/tierlist/team-comps
 Items are in camel case and a-Z
+The higher order champion will get the item first
 """
 
 COMP = {


### PR DESCRIPTION
1. Items will now priority given to champion who have higher order in comps.py when two or above champions need the same item, instead of the order of moving to board.
> Sometimes I just need one RecurveBow to build GuinsoosRageblade and destroy enemy teams, but the bot takes it to other champ who with no item are building. That really bad...

2. Add a check before choosing augment
> Sometimes the augment appears late, and the bot can't recognize the text correctly and click at the background, that will cause buying, moving champ and placing items in that round fails.

3. Swap two for loop positions in pick_augment() in order to follow user defined priority order.