### PR TITLE
skip tacticians_crown_check()

### DIFF
--- a/game.py
+++ b/game.py
@@ -126,7 +126,7 @@ class Game:
         if self.round == "1-3":
             sleep(1.5)
             self.arena.fix_unknown()
-            self.arena.tacticians_crown_check()
+            #self.arena.tacticians_crown_check() #not getting any item in set9 round 1-3, skipped
 
         self.arena.fix_bench_state()
         self.arena.spend_gold()


### PR DESCRIPTION
It wont getting any item in set9 round 1-3, so skipped.
This may avoid the lag discribed in #210 