### PR TITLE
Reconnect when the game failed to connect

### DIFF
--- a/auto_queue.py
+++ b/auto_queue.py
@@ -72,7 +72,7 @@ def check_game_status(client_info: tuple) -> bool:
             timeout=10,
             verify=False,
         )
-        return status.json()["phase"]
+        return status.json().get("phase", "None")
     except ConnectionError:
         return False
 

--- a/auto_queue.py
+++ b/auto_queue.py
@@ -72,7 +72,7 @@ def check_game_status(client_info: tuple) -> bool:
             timeout=10,
             verify=False,
         )
-        return status.json()["phase"] == "InProgress"
+        return status.json()["phase"]
     except ConnectionError:
         return False
 
@@ -124,9 +124,23 @@ def get_client() -> tuple:
     return (remoting_auth_token, server_url)
 
 
+def reconnect(client_info: tuple) -> None:
+    """Reconnect to game when "Failed to Connect" windows are found"""
+    requests.post(
+        f"{client_info[1]}/lol-gameflow/v1/reconnect",
+        auth=HTTPBasicAuth('riot', client_info[0]),
+        timeout=10,
+        verify=False,
+    )
+
+
 def queue() -> None:
     """Function that handles getting into a game"""
     client_info: tuple = get_client()
+    if check_game_status(client_info) == "Reconnect":
+        print("  Reconnecting")
+        reconnect(client_info)
+        return
     while not create_lobby(client_info):
         sleep(3)
 
@@ -148,7 +162,7 @@ def queue() -> None:
             sleep(5)
             start_queue(client_info)
         accept_queue(client_info)
-        if check_game_status(client_info):
+        if check_game_status(client_info) == "InProgress":
             in_queue = False
         sleep(1)
         time += 1

--- a/auto_queue.py
+++ b/auto_queue.py
@@ -137,6 +137,8 @@ def reconnect(client_info: tuple) -> None:
 def queue() -> None:
     """Function that handles getting into a game"""
     client_info: tuple = get_client()
+    while check_game_status(client_info) == "InProgress":
+        sleep(1)
     if check_game_status(client_info) == "Reconnect":
         print("  Reconnecting")
         reconnect(client_info)

--- a/game.py
+++ b/game.py
@@ -74,7 +74,7 @@ class Game:
             print("  Found \"Failed to Connect\" window, trying to exit and reconnect")
             if reconnect_button := win32gui.FindWindowEx(hwnd, 0, "Button", None):
                 if cancel_button := win32gui.FindWindowEx(hwnd, reconnect_button, "Button", None):
-                    print(f"{win32gui.GetWindowText(cancel_button)} button found.")
+                    print(f"  {win32gui.GetWindowText(cancel_button)} button found.")
                     win32gui.SendMessage(cancel_button, BM_CLICK, 0, 0)
                     sleep(5)
                     return True

--- a/game.py
+++ b/game.py
@@ -74,9 +74,8 @@ class Game:
             print("  Found \"Failed to Connect\" window, trying to exit and reconnect")
             if reconnect_button := win32gui.FindWindowEx(hwnd, 0, "Button", None):
                 if cancel_button := win32gui.FindWindowEx(hwnd, reconnect_button, "Button", None):
-                    print(f"  {win32gui.GetWindowText(cancel_button)} button found.")
+                    print(f"{win32gui.GetWindowText(cancel_button)} button found.")
                     win32gui.SendMessage(cancel_button, BM_CLICK, 0, 0)
-                    sleep(5)
                     return True
                 print("  Cancel button not found.")
             else:

--- a/game.py
+++ b/game.py
@@ -61,7 +61,8 @@ class Game:
         """Loop that runs while the game is in the loading screen"""
         game_functions.default_pos()
         while game_functions.get_round() != "1-1":
-            self.check_failed_to_connect_window()
+            if self.check_failed_to_connect_window():
+                return
             sleep(1)
         self.start_time: float = perf_counter()
         self.game_loop()
@@ -75,12 +76,12 @@ class Game:
                 if cancel_button := win32gui.FindWindowEx(hwnd, reconnect_button, "Button", None):
                     print(f"{win32gui.GetWindowText(cancel_button)} button found.")
                     win32gui.SendMessage(cancel_button, BM_CLICK, 0, 0)
-                    sleep(1)
-
-                else:
-                    print("  Cancel button not found.")
+                    sleep(5)
+                    return True
+                print("  Cancel button not found.")
             else:
                 print("  Reconnect button not found.")
+        return False
 
 
     def game_loop(self) -> None:

--- a/game.py
+++ b/game.py
@@ -5,6 +5,7 @@ Handles tasks that happen each game round
 from time import sleep, perf_counter
 import random
 import multiprocessing
+from win32con import BM_CLICK
 import win32gui
 import settings
 import arena_functions
@@ -60,9 +61,27 @@ class Game:
         """Loop that runs while the game is in the loading screen"""
         game_functions.default_pos()
         while game_functions.get_round() != "1-1":
+            self.check_failed_to_connect_window()
             sleep(1)
         self.start_time: float = perf_counter()
         self.game_loop()
+
+    def check_failed_to_connect_window(self) -> bool:
+        """Check "Failed to Connect" windows and try to reconnect"""
+        hwnd = win32gui.FindWindow(None, "Failed to Connect")
+        if hwnd:
+            print("  Found \"Failed to Connect\" window, trying to exit and reconnect")
+            if reconnect_button := win32gui.FindWindowEx(hwnd, 0, "Button", None):
+                if cancel_button := win32gui.FindWindowEx(hwnd, reconnect_button, "Button", None):
+                    print(f"{win32gui.GetWindowText(cancel_button)} button found.")
+                    win32gui.SendMessage(cancel_button, BM_CLICK, 0, 0)
+                    sleep(1)
+
+                else:
+                    print("  Cancel button not found.")
+            else:
+                print("  Reconnect button not found.")
+
 
     def game_loop(self) -> None:
         """Loop that runs while the game is active, handles calling the correct tasks for round and exiting game"""

--- a/game.py
+++ b/game.py
@@ -74,7 +74,7 @@ class Game:
             print("  Found \"Failed to Connect\" window, trying to exit and reconnect")
             if reconnect_button := win32gui.FindWindowEx(hwnd, 0, "Button", None):
                 if cancel_button := win32gui.FindWindowEx(hwnd, reconnect_button, "Button", None):
-                    print(f"{win32gui.GetWindowText(cancel_button)} button found.")
+                    print("  Exiting the game.")
                     win32gui.SendMessage(cancel_button, BM_CLICK, 0, 0)
                     return True
                 print("  Cancel button not found.")


### PR DESCRIPTION
Sometimes lol cant connect and a message window "Failed to connect" shows up, causing the bot stuck at waiting game round '1-1'.
So I made this function to detect this message window, click cancel to close the game(directly click reconnect button wont help), and then reconnect using api.
![FailedToConnect](https://github.com/jfd02/TFT-OCR-BOT/assets/36875936/8655b1dc-8a44-4086-9e32-7e429023cc8d)
