### PR TITLE
Added sleep time after carousel round

### DIFF
--- a/game_functions.py
+++ b/game_functions.py
@@ -42,6 +42,7 @@ def get_champ_carousel(tft_round: str) -> None:
     while tft_round == get_round():
         mk_functions.right_click(screen_coords.CAROUSEL_LOC.get_coords())
         sleep(0.7)
+    sleep(3)
 
 
 def check_alive() -> bool:    # Refactor this function to use API


### PR DESCRIPTION
Preventing right-clicking on unknown champions failed to display the information board and sell directly when jumping out from the portal.